### PR TITLE
Change site intro popup logic

### DIFF
--- a/app/controllers/classify.coffee
+++ b/app/controllers/classify.coffee
@@ -110,13 +110,13 @@ class Classify extends Controller
     @progress = new ProgressBar
     @el.prepend @progress.el
 
-    @el.on StackOfPages::activateEvent, =>
-      @introIfFirstVisit() if @onClassifyPage()
+    @el.on StackOfPages::activateEvent, @introIfFirstVisit
 
   onClassifyPage: ->
     location.hash is '#/classify'
 
   firstVisit: (user) ->
+    return false if user is false
     return true unless user
     !user?.project?.classification_count
 
@@ -126,9 +126,8 @@ class Classify extends Controller
     @introIfFirstVisit() if @onClassifyPage()
     @progressIfFirstVisit(user)
 
-  introIfFirstVisit: ->
-    user = User.current ? false
-    @siteIntro.start() if @firstVisit(user)
+  introIfFirstVisit: =>
+    @siteIntro.start() if @firstVisit User.current
 
   progressIfFirstVisit: (user) ->
     firstVisit = @firstVisit(user)


### PR DESCRIPTION
Address a bug where if a user's first page was #/classify, then they were shown the site intro, regardless if they were a returning user or not.

firstVisit function is now a bit funky, because it relies on User.current to following this pattern:
- false if never fetched
- null if fetched, but no user
- anything else if user

On the assumption that doesn't change, this works.
