### PR TITLE
Build tutorial slides when language changes

### DIFF
--- a/app/controllers/classify.coffee
+++ b/app/controllers/classify.coffee
@@ -120,6 +120,8 @@ class Classify extends Controller
     LanguageManager.on 'change-language', =>
       @siteIntro.nextButtonText = translate('span', 'siteIntro.nextButtonText')
       @siteIntro.finishButtonText = translate('span', 'siteIntro.finishButtonText')
+      @siteIntro.slides = slideTutorialSlides()
+      @siteIntro._createSlides()
 
     @progress = new ProgressBar
     @el.prepend @progress.el

--- a/app/lib/slide-tutorial-slides.coffee
+++ b/app/lib/slide-tutorial-slides.coffee
@@ -1,11 +1,12 @@
 t = require 't7e'
-imageOne = t('span', 'siteIntro.one.image')
-imageTwo = t('span', 'siteIntro.two.image')
-imageThree = t('span', 'siteIntro.three.image')
-imageFour = t('span', 'siteIntro.four.image')
-imageFive = t('span', 'siteIntro.five.image')
 
 module?.exports = ->
+  imageOne = t('span', 'siteIntro.one.image')
+  imageTwo = t('span', 'siteIntro.two.image')
+  imageThree = t('span', 'siteIntro.three.image')
+  imageFour = t('span', 'siteIntro.four.image')
+  imageFive = t('span', 'siteIntro.five.image')
+
   [
     {
       image: $(imageOne).html()


### PR DESCRIPTION
Workaround for lack of i18n support in the slide-tutorial module.
Fixes #97