### PR TITLE
Update jquery

### DIFF
--- a/app/controllers/classify-steps/blue.coffee
+++ b/app/controllers/classify-steps/blue.coffee
@@ -22,7 +22,7 @@ class Blue extends Step
     target = $(e.currentTarget)
 
     @buttons.removeClass 'active'
-    target.prevAll().andSelf().addClass 'active'
+    target.prevAll().addBack().addClass 'active'
 
     @classifier.classification.set @property, parseFloat target.val()
 

--- a/app/controllers/classify-steps/exceeding.coffee
+++ b/app/controllers/classify-steps/exceeding.coffee
@@ -73,7 +73,7 @@ class Exceeding extends Step
     target = $(e.currentTarget)
 
     @buttons.removeClass 'active'
-    target.prevAll().andSelf().addClass 'active'
+    target.prevAll().addBack().addClass 'active'
 
     @classifier.classification.set @property, parseFloat target.val()
 

--- a/app/controllers/classify-steps/surrounding.coffee
+++ b/app/controllers/classify-steps/surrounding.coffee
@@ -22,7 +22,7 @@ class Surrounding extends Step
     target = $(e.currentTarget)
 
     @buttons.removeClass 'active'
-    target.prevAll().andSelf().addClass 'active'
+    target.prevAll().addBack().addClass 'active'
 
     @classifier.classification.set @property, parseFloat target.val()
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "haw": "~0.5.0",
     "publisssh": "~0.2.6",
     "slide-tutorial": "^0.0.2",
-    "stack-of-pages": "git://github.com/chrissnyder/stack-of-pages.git",
+    "stack-of-pages": "git://github.com/zooniverse/stack-of-pages.git",
     "t7e": "~0.4.0",
     "translator-seed": "^0.1.1",
     "zooniverse": "~0.7.1",

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
     <div id="footer-container"></div>
 
     <!--[if lte IE 9]><script src="./js/vendor/Placeholders.js"></script><![endif]-->
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="//code.highcharts.com/3/highcharts.js"></script>
     <script src="//code.highcharts.com/3/highcharts-more.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.5.1/leaflet.js"></script>


### PR DESCRIPTION
This updates to the latest version of jquery and updates the deprecated methods used according to the migration docs. This also updates the stack-of-pages dependency. **The inline tutorial is broken at the moment.** Error thrown might be related to an incompatibility between JQuery 3 and JQuery UI, but using the suggested JQuery migrate version breaks the whole app. Error is:

`Uncaught TypeError: f.getClientRects is not a function`